### PR TITLE
fix: broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ video_data = await doubao_video_parse(
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ihmily/doubao-nomark&type=date&legend=top-left)](https://www.star-history.com/#ihmily/doubao-nomark&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ihmily/doubao-nomark&type=date&legend=top-left)](https://star-history.dera.page/#ihmily/doubao-nomark&type=date&legend=top-left)
 
 ## 许可证
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders, because GitHub stargazer API restrictions broke the underlying service. This PR points the chart at a working star history instance so visitors can see the project's star history again.